### PR TITLE
refactor: change toast msg constants into hard-coded values

### DIFF
--- a/apps/client/src/components/layout/SignInForm/SignInForm.tsx
+++ b/apps/client/src/components/layout/SignInForm/SignInForm.tsx
@@ -8,7 +8,6 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import FieldError from '../../UI/FieldError/FieldError';
 import { toastError, toastSuccess } from '../../UI/Toast/toast';
-import ToastMessages from '../../../constants/toast-messages';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useToggleDrawer } from '../../../contexts/ToggleDrawerContext';
 import { SIGN_IN_MUTATION } from '../../../operations/mutations';
@@ -62,7 +61,7 @@ const SignInForm = () => {
       });
 
       // Display success message
-      toastSuccess(ToastMessages.SIGNED_IN_SUCCESSFULLY);
+      toastSuccess('Signed in successfully 👍');
 
       // On mobile, close drawer component
       closeDrawer();
@@ -81,7 +80,7 @@ const SignInForm = () => {
           }
 
           // Unexpected error
-          toastError(ToastMessages.INTERNAL_SERVER_ERROR);
+          toastError('Something went south 💥');
         }
       }
     },

--- a/apps/client/src/pages/LandingPage/SignUpForm/SignUpForm.tsx
+++ b/apps/client/src/pages/LandingPage/SignUpForm/SignUpForm.tsx
@@ -8,7 +8,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import SignUpHeader from './SignUpHeader/SignUpHeader';
 import FieldError from '../../../components/UI/FieldError/FieldError';
 import { toastError, toastSuccess } from '../../../components/UI/Toast/toast';
-import ToastMessages from '../../../constants/toast-messages';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { SIGN_UP_MUTATION } from '../../../operations/mutations';
 import * as S from './SignUpForm.styled';
@@ -75,7 +74,7 @@ const SignUpForm = () => {
       });
 
       // Display success message
-      toastSuccess(ToastMessages.SIGNED_UP_SUCCESSFULLY);
+      toastSuccess('Signed up successfully 🎉');
     },
     onError: ({ graphQLErrors }) => {
       // Parsing, validation, resolver errors (network errors handled in Apollo Link)
@@ -92,7 +91,7 @@ const SignUpForm = () => {
           }
 
           // Unexpected error
-          toastError(ToastMessages.INTERNAL_SERVER_ERROR);
+          toastError('Something went south 💥');
         }
       }
     },

--- a/apps/client/src/utils/create-apollo-client.ts
+++ b/apps/client/src/utils/create-apollo-client.ts
@@ -11,7 +11,6 @@ import { withScalars } from 'apollo-link-scalars';
 import { GraphQLDate } from 'graphql-scalars';
 import introspectionResult from '../__generated__/introspection.json';
 import { toastError, toastInfo } from '../components/UI/Toast/toast';
-import ToastMessages from '../constants/toast-messages';
 
 const createApolloClient = (logOut: () => void) => {
   // Serialize JS Date types into graphql-scalars' Date scalars, and parse Date scalars into JS Date types
@@ -58,7 +57,7 @@ const createApolloClient = (logOut: () => void) => {
     }
 
     if (networkError) {
-      toastError(ToastMessages.NETWORK_ERROR);
+      toastError('Some network problems. Again. 🌐');
     }
   });
 


### PR DESCRIPTION
Most messages are specific to the context so there is little reuse and it makes it easier to reason about when the message is inline