### PR TITLE
chore(devtools): disable connectToDevTools option during Apollo init

### DIFF
--- a/apps/client/src/utils/create-apollo-client.ts
+++ b/apps/client/src/utils/create-apollo-client.ts
@@ -68,7 +68,7 @@ const createApolloClient = (logOut: () => void) => {
 
   // Initialize Apollo client
   const client = new ApolloClient({
-    connectToDevTools: true,
+    // connectToDevTools: true,
     cache: new InMemoryCache(),
     link: from([dateScalarsLink, authLink, errorLink, httpLink]),
   });


### PR DESCRIPTION
In production it should be disabled for security reasons