### PR TITLE
feat(header): make main header sticky on scroll

### DIFF
--- a/apps/client/src/components/layout/Drawer/Drawer.styled.tsx
+++ b/apps/client/src/components/layout/Drawer/Drawer.styled.tsx
@@ -27,6 +27,7 @@ const fadeOut = keyframes`
 export const DrawerOverlay = styled(Dialog.Overlay)`
   position: fixed;
   inset: 0;
+  z-index: 2;
   background-color: rgb(0 0 0 / 75%);
 
   &[data-state='open'] {
@@ -62,6 +63,7 @@ export const DrawerContent = styled(Flex)`
   position: fixed;
   top: 0;
   right: 0;
+  z-index: 2;
   width: 220px;
   height: 100vh;
   background-color: var(--gray-6);

--- a/apps/client/src/components/layout/MainHeader/MainHeader.styled.tsx
+++ b/apps/client/src/components/layout/MainHeader/MainHeader.styled.tsx
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
 export const MainHeader = styled.header`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: var(--gray-1);
   border-bottom: 1px solid var(--gray-a6);
 `;

--- a/fly.toml
+++ b/fly.toml
@@ -27,7 +27,7 @@ primary_region = "lhr"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 256
 
 [env]
   NODE_ENV = "production"


### PR DESCRIPTION
Added a sticky header because the UX was pretty cumbersome on mobile when needing to scroll back to the top of the page in order to open the menu drawer.

Also updated fly.toml config file to match change made in fly.io console where machine size was updated from 1GB RAM to 256MB in order to stay within the free tier.