### PR TITLE
ci: add daily health check for deployed app

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,16 @@
+name: Health check
+
+on:
+  schedule:
+    # '*' is a special character in YAML, hence the quotation marks
+    - cron: '0 0 * * *'
+
+jobs:
+  health_check:
+    name: 🩺 Check health of deployed app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check deployed app responding at base URL
+        uses: jtalk/url-health-check-action@v3
+        with:
+          url: https://piccy-eater.fly.dev/


### PR DESCRIPTION
Added a cron job in GitHub Actions which pings the deployed app at the base path (/) to ensure availability. Configured to run once a day at midnight.